### PR TITLE
listJobs fix to list all jobs

### DIFF
--- a/crontab.php
+++ b/crontab.php
@@ -189,7 +189,7 @@ class Crontab {
 	* @return string
 	*/
 	function listJobs() {
-		return exec($this->crontab.' -l;');
+		return shell_exec($this->crontab.' -l;');
 	}
 }
 


### PR DESCRIPTION
"exec" only returns last line of output, "shell_exec" returns full output.
